### PR TITLE
Arbitrary code execution fix: Replace exec with spawnSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,7 @@
     "url": "https://github.com/LordAur/KilatStorages3"
   },
   "license": "MIT",
-  "dependencies": {
-    "shelljs": "^0.8.3",
-    "shelljs.exec": "^1.1.8"
-  },
+  "dependencies": {},
   "devDependencies": {
     "eslint": "^5.4.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
### 📊 Metadata *

Fixed Command Injection in s3-kilatstorage using shell-escape.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-s3-kilatstorage/

### ⚙️ Description *

Used `child_process.spawnSync()` instead of `shelljs.exec()`.

### 💻 Technical Description *

The use of the child_process function exec() is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with spawnSync() which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Installation

`npm i s3-kilatstorage`

Run poc.js

```
// poc.js
var a = require("s3-kilatstorage");
a.makeBucket("&  touch HACKED #");
```

`node poc.js`


### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/106030098-cb5b2680-60f3-11eb-918e-7054bd5e39f6.png)

After:
![image](https://user-images.githubusercontent.com/64132745/106030536-4c1a2280-60f4-11eb-8177-d6c42f26e8c2.png)


### 👍 User Acceptance Testing (UAT)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1796
